### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ for rows.Next() {
     user := &Users{}
     err = rows.StructScan(user)
 }
+rows.Close()
 
 //QueryRowx
 user := &Users{}


### PR DESCRIPTION
这里不调用rows.Close()会导致连接泄露。（sqlx的ReadMe也没有调用rows.Close()，易误导使用者）