### PR TITLE
Removing the master-slave vocabulary

### DIFF
--- a/model.go
+++ b/model.go
@@ -107,7 +107,7 @@ func (b *Builder) initModel() {
 	}
 }
 
-// Hint is set TDDL "/*+TDDL:slave()*/"
+// Hint is set TDDL "/*+TDDL:subordinate()*/"
 func (b *Builder) Hint(hint string) *Builder {
 	b.hint = hint
 	return b

--- a/model_test.go
+++ b/model_test.go
@@ -208,7 +208,7 @@ func TestBuilder_Hint(t *testing.T) {
 		insert(2)
 
 		user := make([]*models.Users, 0)
-		err := Model(&user).Hint("/*+TDDL:slave()*/").All()
+		err := Model(&user).Hint("/*+TDDL:subordinate()*/").All()
 
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.